### PR TITLE
Camera - initialize self.lpos on init

### DIFF
--- a/rendercam/camera.script
+++ b/rendercam/camera.script
@@ -66,6 +66,7 @@ function init(self)
 	end
 
 	-- Get initial vectors & stuff
+	self.lpos = go.get_position()
 	self.wpos = go.get_world_position()
 	self.wrot = go.get_world_rotation()
 	self.wforwardVec = vmath.rotate(self.wrot, FORWARDVEC)


### PR DESCRIPTION
- Before, it was nil until the first update, causing pan() to break if called on init