### PR TITLE
Update render script

### DIFF
--- a/rendercam/rendercam.render_script
+++ b/rendercam/rendercam.render_script
@@ -14,13 +14,13 @@ local function update_window(self)
 end
 
 function init(self)
-    self.tile_pred = render.predicate({"tile"})
-    self.gui_pred = render.predicate({"gui"})
-    self.text_pred = render.predicate({"text"})
-    self.model_pred = render.predicate({"model"})
-    self.particle_pred = render.predicate({"particle"})
+	self.tile_pred = render.predicate({"tile"})
+	self.gui_pred = render.predicate({"gui"})
+	self.text_pred = render.predicate({"text"})
+	self.model_pred = render.predicate({"model"})
+	self.particle_pred = render.predicate({"particle"})
 
-    self.clear_color = vmath.vector4(0)
+	self.clear_color = vmath.vector4(0)
 
 	rendercam.configWin.x = render.get_width();  rendercam.configWin.y = render.get_height()
 	rendercam.update_window_size(render.get_window_width(), render.get_window_height())
@@ -28,59 +28,55 @@ function init(self)
 end
 
 function update(self)
-	-- Set view and projection with latest matrices calculated by the module
+	render.set_depth_mask(true)
+	render.set_stencil_mask(0xff)
+	render.clear({[render.BUFFER_COLOR_BIT] = self.clear_color, [render.BUFFER_DEPTH_BIT] = 1, [render.BUFFER_STENCIL_BIT] = 0})
+
+	render.set_viewport(vp.x, vp.y, vp.width, vp.height)
+
 	render.set_view(rendercam.calculate_view())
 	render.set_projection(rendercam.calculate_proj())
 
-	-- Set viewport (x and y will be zero unless using a fixed aspect ratio)
-	render.set_viewport(vp.x, vp.y, vp.width, vp.height)
+	-- Sprite and particle rendering
+	render.set_depth_mask(false)
+	render.disable_state(render.STATE_DEPTH_TEST)
+	render.disable_state(render.STATE_STENCIL_TEST)
+	render.enable_state(render.STATE_BLEND)
+	render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
+	render.disable_state(render.STATE_CULL_FACE)
 
-    render.set_depth_mask(true)
-    render.clear({[render.BUFFER_COLOR_BIT] = self.clear_color, [render.BUFFER_DEPTH_BIT] = 1, [render.BUFFER_STENCIL_BIT] = 0})
+	render.draw(self.tile_pred)
+	render.draw(self.particle_pred)
 
-    render.set_depth_mask(false)
-    render.disable_state(render.STATE_DEPTH_TEST)
-    render.disable_state(render.STATE_STENCIL_TEST)
-    render.enable_state(render.STATE_BLEND)
-    render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
-    render.disable_state(render.STATE_CULL_FACE)
-
-    render.draw(self.tile_pred)
-    render.draw(self.particle_pred)
-
+	-- Model rendering
 	render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
 	render.enable_state(render.STATE_CULL_FACE)
-    render.enable_state(render.STATE_DEPTH_TEST)
-    render.set_depth_mask(true)
-    render.draw(self.model_pred)
+	render.enable_state(render.STATE_DEPTH_TEST)
+	render.set_depth_mask(true)
+	render.draw(self.model_pred)
 
-	-- Physics debug and draw_line rendering
+	-- Debug rendering - physics debug, draw_line
 	render.disable_state(render.STATE_DEPTH_TEST)
 	render.disable_state(render.STATE_CULL_FACE)
 	render.draw_debug3d()
 
 	-- GUI Rendering
 	render.set_viewport(0, 0, rendercam.window.x, rendercam.window.y)
-    render.set_view(IDENTITY_MATRIX)
+	render.set_view(IDENTITY_MATRIX)
 	render.set_projection(self.gui_proj) -- gui_proj only calculated on update_window
 
-	render.disable_state(render.STATE_CULL_FACE)
-    render.disable_state(render.STATE_DEPTH_TEST)
-    render.enable_state(render.STATE_STENCIL_TEST)
-    render.draw(self.gui_pred)
-    render.draw(self.text_pred)
-    render.disable_state(render.STATE_STENCIL_TEST)
-
-    render.set_depth_mask(false)
-    render.draw_debug2d()
+	render.enable_state(render.STATE_STENCIL_TEST)
+	render.draw(self.gui_pred)
+	render.draw(self.text_pred) -- Includes debug text from "draw_text" messages.
+	render.disable_state(render.STATE_STENCIL_TEST)
 end
 
 function on_message(self, message_id, message)
-    if message_id == CLEAR_COLOR then
-        self.clear_color = message.color
+	if message_id == CLEAR_COLOR then
+		self.clear_color = message.color
 	elseif message_id == WINDOW_RESIZED then -- sent by engine
 		update_window(self)
 	elseif message_id == UPDATE_WINDOW then -- sent by rendercam when a camera is activated ("window_resized" engine message requires data)
 		update_window(self)
-    end
+	end
 end


### PR DESCRIPTION
- Remove deprecated `render.draw_debug2d()`
- Set stencil mask.
- Fix tabs.
- Rearrange things a bit and remove some unnecessar state changes.

Based on the latest built-in render script and the model rendering
script in the render manual.