### PR TITLE
Fix for the issue "Version of screen_to_world_2d which can return x,y and not a new vec3"

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ _PARAMETERS_
 _RETURNS_
 * __pos__ <kbd>vector3</kbd> - World position.
 
+### rendercam.screen_to_world_2d_raw(x, y, [delta], [worldz])
+Same as above, but returns x and y values instead of a new vector for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
+
+_RETURNS_
+* __x__ <kbd>number</kbd> - World position X.
+* __y__ <kbd>number</kbd> - World position Y.
+
 ### rendercam.screen_to_world_ray(x, y)
 Takes `x` and `y` screen coordinates and returns two points describing the start and end of a ray from the camera's near plane to its far plane, through that point on the screen. You can use these points to cast a ray to check for collisions "underneath" the mouse cursor, or any other screen point.
 
@@ -251,6 +258,17 @@ _PARAMETERS_
 _RETURNS_
 * __start__ <kbd>vector3</kbd> - Start point on the camera near plane, in world coordinates.
 * __end__ <kbd>vector3</kbd> - End point on the camera far plane, in world coordinates.
+
+### rendercam.screen_to_world_ray_raw(x, y)
+Same as above, but returns x1, y1, z1, x2, y2, z2 values instead of new vectors for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
+
+_RETURNS_
+* __x1__ <kbd>number</kbd> - X value of start point on the camera near plane, in world coordinates.
+* __y1__ <kbd>number</kbd> - Y value of start point on the camera near plane, in world coordinates.
+* __z1__ <kbd>number</kbd> - Z value of start point on the camera near plane, in world coordinates.
+* __x2__ <kbd>number</kbd> - X value of end point on the camera far plane, in world coordinates.
+* __y2__ <kbd>number</kbd> - Y value of end point on the camera far plane, in world coordinates.
+* __z2__ <kbd>number</kbd> - Z value of end point on the camera far plane, in world coordinates.
 
 ### rendercam.screen_to_world_plane(x, y, planeNormal, pointOnPlane)
 Gets the screen-to-world ray and intersects it with a world-space plane. The equivalent of `rendercam.screen_to_world_2d` for 3D cameras. Note: this will return `nil` if the camera angle is exactly parallel to the plane (perpendicular to the normal).
@@ -317,6 +335,13 @@ _PARAMETERS_
 
 _RETURNS_
 * __pos__ <kbd>vector3</kbd> - Screen position
+
+### rendercam.world_to_screen_raw(pos, [adjust])
+Same as above, but returns x and y values instead of a new vector for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
+
+_RETURNS_
+* __x__ <kbd>number</kbd> - Screen position X.
+* __y__ <kbd>number</kbd> - Screen position Y.
 
 ## Custom Render Scripts
 For a lot of projects you will want to write your own custom render script, to mess with material predicates, use render targets, etc. You can definitely do that with Rendercam. Just copy the "rendercam.render_script" out of the rendercam folder, hook it up, and change whatever you want in it. The Rendercam render script is not very complicated, all the real work is done in the rendercam module. As long as you don't change the view, projection, or viewport stuff, you should be able to do whatever you want without interfering with Rendercam.

--- a/README.md
+++ b/README.md
@@ -242,11 +242,18 @@ _RETURNS_
 * __pos__ <kbd>vector3</kbd> - World position.
 
 ### rendercam.screen_to_world_2d_raw(x, y, [delta], [worldz])
-Same as above, but returns x and y values instead of a new vector for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
+Same as above, but returns x, y, and z values instead of a new vector for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
+
+_PARAMETERS_
+* __x__ <kbd>number</kbd> - Screen X
+* __y__ <kbd>number</kbd> - Screen Y
+* __delta__ <kbd>bool</kbd> - If `x` and `y` are for a delta (change in) screen position, rather than an absolute screen position.
+* __worlds__ <kbd>number</kbd> - World Z position to find the X and Y coordinates at. Defaults to the current camera's "2d World Z" setting.
 
 _RETURNS_
 * __x__ <kbd>number</kbd> - World position X.
 * __y__ <kbd>number</kbd> - World position Y.
+* __z__ <kbd>number</kbd> - World position Z.
 
 ### rendercam.screen_to_world_ray(x, y)
 Takes `x` and `y` screen coordinates and returns two points describing the start and end of a ray from the camera's near plane to its far plane, through that point on the screen. You can use these points to cast a ray to check for collisions "underneath" the mouse cursor, or any other screen point.
@@ -261,6 +268,10 @@ _RETURNS_
 
 ### rendercam.screen_to_world_ray_raw(x, y)
 Same as above, but returns x1, y1, z1, x2, y2, z2 values instead of new vectors for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
+
+_PARAMETERS_
+* __x__ <kbd>number</kbd> - Screen X
+* __y__ <kbd>number</kbd> - Screen Y
 
 _RETURNS_
 * __x1__ <kbd>number</kbd> - X value of start point on the camera near plane, in world coordinates.
@@ -337,11 +348,26 @@ _RETURNS_
 * __pos__ <kbd>vector3</kbd> - Screen position
 
 ### rendercam.world_to_screen_raw(pos, [adjust])
-Same as above, but returns x and y values instead of a new vector for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
+Same as above, but returns x, y, and z values instead of a new vector for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
+
+_PARAMETERS_
+* __pos__ <kbd>vector3</kbd> - World position.
+* __adjust__ <kbd>constant</kbd> - GUI adjust mode to use for calculation.
+    * You can use
+	    * gui.ADJUST_FIT
+		* gui.ADJUST_ZOOM
+		* gui.ADJUST_STRETCH
+	* Or
+	    * rendercam.GUI_ADJUST_FIT
+		* rendercam.GUI_ADJUST_ZOOM
+		* rendercam.GUI_ADJUST_STRETCH
+	* _Or_
+		* The result of `gui.get_adjust_mode`
 
 _RETURNS_
 * __x__ <kbd>number</kbd> - Screen position X.
 * __y__ <kbd>number</kbd> - Screen position Y.
+* __z__ <kbd>number</kbd> - Screen position Z.
 
 ## Custom Render Scripts
 For a lot of projects you will want to write your own custom render script, to mess with material predicates, use render targets, etc. You can definitely do that with Rendercam. Just copy the "rendercam.render_script" out of the rendercam folder, hook it up, and change whatever you want in it. The Rendercam render script is not very complicated, all the real work is done in the rendercam module. As long as you don't change the view, projection, or viewport stuff, you should be able to do whatever you want without interfering with Rendercam.

--- a/README.md
+++ b/README.md
@@ -229,51 +229,37 @@ _RETURNS_
 * __x__ <kbd>number</kbd> - Viewport X.
 * __y__ <kbd>number</kbd> - Viewport Y.
 
-### rendercam.screen_to_world_2d(x, y, [delta], [worldz])
-Transforms `x` and `y` from screen coordinates to world coordinates at a certain Z position—either a specified `worldz` or by default the current camera's "2d World Z". This function returns a position on a plane perpendicular to the camera angle, so it's only accurate for 2D-oriented cameras (facing along the Z axis). It works for 2D-oriented perspective cameras, but will have some small imprecision based on the size of the view depth (farZ - nearZ). For 3D cameras, use `rendercam.screen_to_world_plane` or `rendercam.screen_to_world_ray`.
+### rendercam.screen_to_world_2d(x, y, [delta], [worldz], [raw])
+Transforms `x` and `y` from screen coordinates to world coordinates at a certain Z position—either a specified `worldz` or by default the current camera's "2d World Z". This function returns a position on a plane perpendicular to the camera angle, so it's only accurate for 2D-oriented cameras (facing along the Z axis). It works for 2D-oriented perspective cameras, but will have some small imprecision based on the size of the view depth (farZ - nearZ). For 3D cameras, use `rendercam.screen_to_world_plane` or `rendercam.screen_to_world_ray`. Set the [raw] parameter to true to return raw x, y, and z values instead of a vector. This provides a minor performance improvement since returning a vector creates more garbage for the garbage collector.
 
 _PARAMETERS_
 * __x__ <kbd>number</kbd> - Screen X
 * __y__ <kbd>number</kbd> - Screen Y
 * __delta__ <kbd>bool</kbd> - If `x` and `y` are for a delta (change in) screen position, rather than an absolute screen position.
 * __worlds__ <kbd>number</kbd> - World Z position to find the X and Y coordinates at. Defaults to the current camera's "2d World Z" setting.
+* __raw__ <kbd>bool</kbd> - If the function should return a vector (nil/false), or return raw x, y, and z values (true)
 
-_RETURNS_
+_RETURNS if raw is nil/false_
 * __pos__ <kbd>vector3</kbd> - World position.
 
-### rendercam.screen_to_world_2d_raw(x, y, [delta], [worldz])
-Same as above, but returns x, y, and z values instead of a new vector for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
-
-_PARAMETERS_
-* __x__ <kbd>number</kbd> - Screen X
-* __y__ <kbd>number</kbd> - Screen Y
-* __delta__ <kbd>bool</kbd> - If `x` and `y` are for a delta (change in) screen position, rather than an absolute screen position.
-* __worlds__ <kbd>number</kbd> - World Z position to find the X and Y coordinates at. Defaults to the current camera's "2d World Z" setting.
-
-_RETURNS_
+_RETURNS if raw is true_
 * __x__ <kbd>number</kbd> - World position X.
 * __y__ <kbd>number</kbd> - World position Y.
 * __z__ <kbd>number</kbd> - World position Z.
 
-### rendercam.screen_to_world_ray(x, y)
-Takes `x` and `y` screen coordinates and returns two points describing the start and end of a ray from the camera's near plane to its far plane, through that point on the screen. You can use these points to cast a ray to check for collisions "underneath" the mouse cursor, or any other screen point.
+### rendercam.screen_to_world_ray(x, y, [raw])
+Takes `x` and `y` screen coordinates and returns two points describing the start and end of a ray from the camera's near plane to its far plane, through that point on the screen. You can use these points to cast a ray to check for collisions "underneath" the mouse cursor, or any other screen point. Set the [raw] parameter to true to return raw x, y, and z values instead of vectors. This provides a minor performance improvement since returning vectors creates more garbage for the garbage collector.
 
 _PARAMETERS_
 * __x__ <kbd>number</kbd> - Screen X
 * __y__ <kbd>number</kbd> - Screen Y
+* __raw__ <kbd>bool</kbd> - If the function should return vectors (nil/false), or return raw x, y, and z values (true)
 
-_RETURNS_
+_RETURNS if raw is nil/false_
 * __start__ <kbd>vector3</kbd> - Start point on the camera near plane, in world coordinates.
 * __end__ <kbd>vector3</kbd> - End point on the camera far plane, in world coordinates.
 
-### rendercam.screen_to_world_ray_raw(x, y)
-Same as above, but returns x1, y1, z1, x2, y2, z2 values instead of new vectors for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
-
-_PARAMETERS_
-* __x__ <kbd>number</kbd> - Screen X
-* __y__ <kbd>number</kbd> - Screen Y
-
-_RETURNS_
+_RETURNS if raw is true_
 * __x1__ <kbd>number</kbd> - X value of start point on the camera near plane, in world coordinates.
 * __y1__ <kbd>number</kbd> - Y value of start point on the camera near plane, in world coordinates.
 * __z1__ <kbd>number</kbd> - Z value of start point on the camera near plane, in world coordinates.
@@ -327,8 +313,8 @@ _RETURNS_
 * __x__ <kbd>number</kbd> - X
 * __y__ <kbd>number</kbd> - Y
 
-### rendercam.world_to_screen(pos, [adjust])
-Transforms the supplied world position into screen (viewport) coordinates. Can take an optional `adjust` parameter to calculate an accurate screen coordinate for a gui node with any adjust mode: Fit, Zoom, or Stretch.
+### rendercam.world_to_screen(pos, [adjust], [raw])
+Transforms the supplied world position into screen (viewport) coordinates. Can take an optional `adjust` parameter to calculate an accurate screen coordinate for a gui node with any adjust mode: Fit, Zoom, or Stretch. Set the [raw] parameter to true to return raw x, y, and z values instead of a vector. This provides a minor performance improvement since returning a vector creates more garbage for the garbage collector.
 
 _PARAMETERS_
 * __pos__ <kbd>vector3</kbd> - World position.
@@ -343,28 +329,12 @@ _PARAMETERS_
 		* rendercam.GUI_ADJUST_STRETCH
 	* _Or_
 		* The result of `gui.get_adjust_mode`
+* __raw__ <kbd>bool</kbd> - If the function should return a vector (nil/false), or return raw x, y, and z values (true)
 
-_RETURNS_
+_RETURNS if raw is nil/false_
 * __pos__ <kbd>vector3</kbd> - Screen position
 
-### rendercam.world_to_screen_raw(pos, [adjust])
-Same as above, but returns x, y, and z values instead of a new vector for a minor performance improvement. (New vectors create more garbage that needs to be collected.)
-
-_PARAMETERS_
-* __pos__ <kbd>vector3</kbd> - World position.
-* __adjust__ <kbd>constant</kbd> - GUI adjust mode to use for calculation.
-    * You can use
-	    * gui.ADJUST_FIT
-		* gui.ADJUST_ZOOM
-		* gui.ADJUST_STRETCH
-	* Or
-	    * rendercam.GUI_ADJUST_FIT
-		* rendercam.GUI_ADJUST_ZOOM
-		* rendercam.GUI_ADJUST_STRETCH
-	* _Or_
-		* The result of `gui.get_adjust_mode`
-
-_RETURNS_
+_RETURNS if raw is true_
 * __x__ <kbd>number</kbd> - Screen position X.
 * __y__ <kbd>number</kbd> - Screen position Y.
 * __z__ <kbd>number</kbd> - Screen position Z.

--- a/rendercam/rendercam.lua
+++ b/rendercam/rendercam.lua
@@ -49,6 +49,9 @@ M.GUI_ADJUST_STRETCH = 2
 local cameras = {} -- master table of camera data tables. Elements added and removed on M.camera_init and M.camera_final
 local curCam = fallback_cam -- current camera data table, defaults and resets to `fallback_cam` if no user camera is active
 
+-- Vectors used in calculations for public transform functions
+local nv = vmath.vector4(0, 0, -1, 1)
+local fv = vmath.vector4(0, 0, 1, 1)
 
 -- ---------------------------------------------------------------------------------
 --| 							PRIVATE FUNCTIONS									|
@@ -353,14 +356,44 @@ function M.screen_to_world_2d(x, y, delta, worldz)
 
 	if delta then x1 = x1 + 1;  y1 = y1 + 1 end
 
-	local np = m * vmath.vector4(x1, y1, -1, 1)
-	local fp = m * vmath.vector4(x1, y1, 1, 1)
+	nv.x, nv.y = x1, y1
+	fv.x, fv.y = x1, y1
+	local np = m * nv
+	local fp = m * fv
 	np = np * (1/np.w)
 	fp = fp * (1/fp.w)
 
 	local t = ( worldz - curCam.abs_nearZ) / (curCam.abs_farZ - curCam.abs_nearZ) -- normalize desired Z to 0-1 from abs_nearZ to abs_farZ
 	local worldpos = vmath.lerp(t, np, fp)
 	return vmath.vector3(worldpos.x, worldpos.y, worldpos.z) -- convert vector4 to vector3
+end
+
+-- Same as M.screen_to_world_2d but returns raw x,y values instead of a new vector
+function M.screen_to_world_2d_raw(x, y, delta, worldz)
+	worldz = worldz or curCam.worldZ
+
+	if curCam.fixedAspectRatio then
+		x, y = M.screen_to_viewport(x, y, delta)
+	end
+
+	local m = not delta and vmath.inv(M.proj * M.view) or vmath.inv(M.proj)
+
+	-- Remap coordinates to range -1 to 1
+	x1 = (x - M.window.x * 0.5) / M.window.x * 2
+	y1 = (y - M.window.y * 0.5) / M.window.y * 2
+
+	if delta then x1 = x1 + 1;  y1 = y1 + 1 end
+
+	nv.x, nv.y = x1, y1
+	fv.x, fv.y = x1, y1
+	local np = m * nv
+	local fp = m * fv
+	np = np * (1/np.w)
+	fp = fp * (1/fp.w)
+
+	local t = ( worldz - curCam.abs_nearZ) / (curCam.abs_farZ - curCam.abs_nearZ) -- normalize desired Z to 0-1 from abs_nearZ to abs_farZ
+	local worldpos = vmath.lerp(t, np, fp)
+	return worldpos.x, worldpos.y
 end
 
 -- Returns start and end points for a ray from the camera through the supplied screen coordinates
@@ -376,12 +409,36 @@ function M.screen_to_world_ray(x, y)
 	local x1 = (x - M.window.x * 0.5) / M.window.x * 2
 	local y1 = (y - M.window.y * 0.5) / M.window.y * 2
 
-	local np = m * vmath.vector4(x1, y1, -1, 1)
-	local fp = m * vmath.vector4(x1, y1, 1, 1)
+	nv.x, nv.y = x1, y1
+	fv.x, fv.y = x1, y1
+	local np = m * nv
+	local fp = m * fv
 	np = np * (1/np.w)
 	fp = fp * (1/fp.w)
 
 	return vmath.vector3(np.x, np.y, np.z), vmath.vector3(fp.x, fp.y, fp.z)
+end
+
+-- Same as M.screen_to_world_ray but returns raw x1,y1,z1,x2,y2,z2 values instead of a new vector
+function M.screen_to_world_ray_raw(x, y)
+	if curCam.fixedAspectRatio then -- convert screen coordinates to viewport coordinates
+		x, y = M.screen_to_viewport(x, y)
+	end
+
+	local m = vmath.inv(M.proj * M.view)
+
+	-- Remap coordinates to range -1 to 1
+	local x1 = (x - M.window.x * 0.5) / M.window.x * 2
+	local y1 = (y - M.window.y * 0.5) / M.window.y * 2
+
+	nv.x, nv.y = x1, y1
+	fv.x, fv.y = x1, y1
+	local np = m * nv
+	local fp = m * fv
+	np = np * (1/np.w)
+	fp = fp * (1/fp.w)
+
+	return np.x, np.y, np.z, fp.x, fp.y, fp.z
 end
 
 -- Gets screen to world ray and intersects it with a plane
@@ -428,5 +485,22 @@ function M.world_to_screen(pos, adjust)
 	return vmath.vector3(pos.x, pos.y, 0)
 end
 
+-- Same as M.world_to_screen but returns raw x,y values instead of a new vector
+function M.world_to_screen_raw(pos, adjust)
+	local m = M.proj * M.view
+	pos = vmath.vector4(pos.x, pos.y, pos.z, 1)
+
+	pos = m * pos
+	pos = pos * (1/pos.w)
+	pos.x = (pos.x / 2 + 0.5) * M.viewport.width + M.viewport.x
+	pos.y = (pos.y / 2 + 0.5) * M.viewport.height + M.viewport.y
+
+	if adjust then
+		pos.x = pos.x / M.guiAdjust[adjust].sx - M.guiAdjust[adjust].ox
+		pos.y = pos.y / M.guiAdjust[adjust].sy - M.guiAdjust[adjust].oy
+	end
+
+	return pos.x, pos.y
+end
 
 return M

--- a/rendercam/rendercam.lua
+++ b/rendercam/rendercam.lua
@@ -394,7 +394,7 @@ function M.screen_to_world_2d_raw(x, y, delta, worldz)
 
 	local t = ( worldz - curCam.abs_nearZ) / (curCam.abs_farZ - curCam.abs_nearZ) -- normalize desired Z to 0-1 from abs_nearZ to abs_farZ
 	local worldpos = vmath.lerp(t, np, fp)
-	return worldpos.x, worldpos.y
+	return worldpos.x, worldpos.y, worldpos.z
 end
 
 -- Returns start and end points for a ray from the camera through the supplied screen coordinates
@@ -501,7 +501,7 @@ function M.world_to_screen_raw(pos, adjust)
 		pv.y = pv.y / M.guiAdjust[adjust].sy - M.guiAdjust[adjust].oy
 	end
 
-	return pv.x, pv.y
+	return pv.x, pv.y, 0
 end
 
 return M

--- a/rendercam/rendercam.lua
+++ b/rendercam/rendercam.lua
@@ -52,6 +52,7 @@ local curCam = fallback_cam -- current camera data table, defaults and resets to
 -- Vectors used in calculations for public transform functions
 local nv = vmath.vector4(0, 0, -1, 1)
 local fv = vmath.vector4(0, 0, 1, 1)
+local pv = vmath.vector4(0, 0, 0, 1)
 
 -- ---------------------------------------------------------------------------------
 --| 							PRIVATE FUNCTIONS									|
@@ -470,37 +471,37 @@ end
 
 function M.world_to_screen(pos, adjust)
 	local m = M.proj * M.view
-	pos = vmath.vector4(pos.x, pos.y, pos.z, 1)
+	pv.x, pv.y, pv.z, pv.w = pos.x, pos.y, pos.z, 1
 
-	pos = m * pos
-	pos = pos * (1/pos.w)
-	pos.x = (pos.x / 2 + 0.5) * M.viewport.width + M.viewport.x
-	pos.y = (pos.y / 2 + 0.5) * M.viewport.height + M.viewport.y
+	pv = m * pv
+	pv = pv * (1/pv.w)
+	pv.x = (pv.x / 2 + 0.5) * M.viewport.width + M.viewport.x
+	pv.y = (pv.y / 2 + 0.5) * M.viewport.height + M.viewport.y
 
 	if adjust then
-		pos.x = pos.x / M.guiAdjust[adjust].sx - M.guiAdjust[adjust].ox
-		pos.y = pos.y / M.guiAdjust[adjust].sy - M.guiAdjust[adjust].oy
+		pv.x = pv.x / M.guiAdjust[adjust].sx - M.guiAdjust[adjust].ox
+		pv.y = pv.y / M.guiAdjust[adjust].sy - M.guiAdjust[adjust].oy
 	end
 
-	return vmath.vector3(pos.x, pos.y, 0)
+	return vmath.vector3(pv.x, pv.y, 0)
 end
 
 -- Same as M.world_to_screen but returns raw x,y values instead of a new vector
 function M.world_to_screen_raw(pos, adjust)
 	local m = M.proj * M.view
-	pos = vmath.vector4(pos.x, pos.y, pos.z, 1)
+	pv.x, pv.y, pv.z, pv.w = pos.x, pos.y, pos.z, 1
 
-	pos = m * pos
-	pos = pos * (1/pos.w)
-	pos.x = (pos.x / 2 + 0.5) * M.viewport.width + M.viewport.x
-	pos.y = (pos.y / 2 + 0.5) * M.viewport.height + M.viewport.y
+	pv = m * pv
+	pv = pv * (1/pv.w)
+	pv.x = (pv.x / 2 + 0.5) * M.viewport.width + M.viewport.x
+	pv.y = (pv.y / 2 + 0.5) * M.viewport.height + M.viewport.y
 
 	if adjust then
-		pos.x = pos.x / M.guiAdjust[adjust].sx - M.guiAdjust[adjust].ox
-		pos.y = pos.y / M.guiAdjust[adjust].sy - M.guiAdjust[adjust].oy
+		pv.x = pv.x / M.guiAdjust[adjust].sx - M.guiAdjust[adjust].ox
+		pv.y = pv.y / M.guiAdjust[adjust].sy - M.guiAdjust[adjust].oy
 	end
 
-	return pos.x, pos.y
+	return pv.x, pv.y
 end
 
 return M


### PR DESCRIPTION
I haven't tested this yet, and there are a few questions I have.

I added some alternate public transform functions that returns the raw coordinate values instead of returning a new vector. This adds a minor performance improvement by producing less work for the garbage collector. This addresses the issue "Version of screen_to_world_2d which can return x,y and not a new vec3" opened by subsoap.

I also replaced some of the vectors that are created every time to do calculations with local variables that are reused.

These are the questions I have:

Should M.screen_to_world_2d_raw() also return a z coordinate?

Are the functions M.screen_to_world_ray_raw() and M.world_to_screen_raw() necessary? Would they be called often enough to need optimization? I know that screen_to_world_2d_raw() would be useful. In the games I created that use mouse/touch input, rendercam.screen_to_world_2d() is usually called on every single input update (which happens a lot when the mouse moves).

If those other two functions are necessary, do they need to return the z coordinate?

Should there be any concern with the thread safety of using the local np, nv, and pv variables? If there are multiple rendercam modules in a scene and two transform functions get called at the same time from different locations, would Defold process them in different threads and possibly cause a collision? If that is the case, then they should be M.np, M.nv, and M.pv instead.